### PR TITLE
Flush stdout after printf with PTY name

### DIFF
--- a/main.c
+++ b/main.c
@@ -322,6 +322,7 @@ static int open_pty(void)
     }
 
     printf("PTY name is %s\n", ptsname(fdm));
+    fflush(stdout);
 
     return fdm;
 }


### PR DESCRIPTION
This is useful when another program wants to read the name
of PTY from stdout.